### PR TITLE
Remove unneeded fixture for 2024 video refresh

### DIFF
--- a/tests/chp2/video7/test_sad_path_end.py
+++ b/tests/chp2/video7/test_sad_path_end.py
@@ -3,15 +3,11 @@ import pytest
 from scripts.chp2.video7 import data_processor_end as data_processor
 
 
-@pytest.fixture(scope="function")
-def city_list_location_malformed():
-    return 'tests/resources/cities/malformed_map.csv'
-
-
-def test_csv_reader_malformed_data_contents(city_list_location_malformed):
+def test_csv_reader_malformed_data_contents():
     """
     Sad Path Test
     """
+    city_list_location_malformed = "tests/resources/cities/malformed_map.csv"
     with pytest.raises(ValueError) as exp:
         data_processor.csv_reader(city_list_location_malformed)
     assert str(exp.value) == "Invalid input: could not convert string to float: 'not_an_altitude'"


### PR DESCRIPTION
Since fixtures are not explained until chapter 3, we can remove this from the code to not distract learners and improve continuity.