### PR TITLE
~ upgrade to `pytest 6.2.5`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,3 @@ if __name__ == '__main__':
           'Topic :: Software Development :: Libraries :: Python Modules'
       ],
     )
-
-
-
-

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 coverage==4.5.2
-pytest==5.2.0
+pytest==6.2.5
 pytest-cov==2.6.1
 pytest-flakes==2.0.0
 pytest-pep8


### PR DESCRIPTION
'''test-requirements.txt''' √
› pytest==6.2.5

» Issue:

``` bash
(.venv) dragancajic@ubuntu:~/Devs/pytest-and-docker$ pytest
TypeError: required field "lineno" missing from alias
```

» Solution: :checkered_flag: ✔️

Pytest issues >> TypeError: required field "lineno" missing from alias · pytest-dev/pytest · Discussion #9195 https://github.com/pytest-dev/pytest/discussions/9195

Error running pytest: "TypeError: required field "lineno" missing from alias" · Issue #171 · tokenspice/tokenspice https://github.com/tokenspice/tokenspice/issues/171

The fix is to force pytest >= 6.2.5
Details: pytest-dev/pytest#9195