### PR TITLE
Remove deprecated pytest stuff for newer Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-buster
+FROM python:3.12
 
 RUN mkdir /pytest_project/
 COPY ./test-requirements.txt /pytest_project/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.1'
 services:
   test:
     build: .

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,10 +2,7 @@
 description-file = README.md
 
 [pytest]
-python_paths = scripts
 testpaths = tests
-addopts = --pep8 --flakes --verbose --durations=10 --color=yes
-pep8maxlinelength=100
+addopts = --flakes --verbose --durations=10 --color=yes
 markers =
-    pep8: pep8 style check
     flakes: pyflakes style check

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,8 @@
-coverage==4.5.2
-pytest==5.2.0
-pytest-cov==2.6.1
-pytest-flakes==2.0.0
-pytest-pep8
+coverage
+pytest
+pytest-cov
+pytest-flakes
+# pytest-pep8
+pytest-pycodestyle
 pytest-pythonpath
 docker


### PR DESCRIPTION
There were a number of changes required to make this work with a newer version of Python.  I've made these changes and tested with 3.10 and newer.

Changes are:
- Updated Dockerfile to Python 3.12 rather than 3.7-bustser
- Removed deprecated version attribute from compose file
- Removed python_paths variable from pytests, which causes a key error and is not required
- Removed all references to pep8, since it is no longer supported
- Updated requirements to resolve incompatible dependencies